### PR TITLE
Add address for `_CxxThrowException`

### DIFF
--- a/patcher/Patcher.py
+++ b/patcher/Patcher.py
@@ -102,6 +102,7 @@ __ZdlPvj = 0x958C40;
 "___CxxFrameHandler3" = 0xA8958C;
 "___std_terminate" = 0xA994FB; /*idk addr*/
 "??_7type_info@@6B@" = 0xD72A88;
+"__CxxThrowException@8" = 0x00A89950;
     """
     SECTIONS = """
     SECTIONS {


### PR DESCRIPTION
Allows throwing exceptions. In clang compiled code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal symbol configuration for compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->