### PR TITLE
Patcher improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,9 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          path: fa-python-binary-patcher
+          repository: FAForever/FA-Binary-Patches
+          ref: 'master'
+          path: FA-Binary-Patches
 
       # install everything that we need
       - uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,6 @@ jobs:
       # clone everything that we need
       - uses: actions/checkout@v4
         with:
-          repository: FAForever/FA-Binary-Patches
-          ref: 'master'
           path: .
 
       - uses: actions/checkout@v4
@@ -52,7 +50,7 @@ jobs:
       # install everything that we need
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install MinGW i686
         run: choco install mingw --x86 -y --no-progress
@@ -60,17 +58,13 @@ jobs:
       - name: Update PATH
         run: echo C:/ProgramData/mingw64/mingw32/bin/ >> $env:GITHUB_PATH
 
-      - name: Install fa-python-binary-patcher
-        run: |
-          pip install -r ./fa-python-binary-patcher/requirements.txt
-
       # download base executable
       - name: Download base executable
         run: | 
-          curl -L "https://content.faforever.com/build/ForgedAlliance_base.exe" -o ForgedAlliance_base.exe
+          curl -L "https://content.faforever.com/build/ForgedAlliance_base.exe" -o FA-Binary-Patches/ForgedAlliance_base.exe
 
       # patch it, if it works then we're good
       - name: Patch base executable
         run: |
-          mkdir build
-          python ./fa-python-binary-patcher/main.py "$(pwd)" clang++ ld g++
+          mkdir FA-Binary-Patches/build
+          cd fa-python-binary-patcher & python main.py FA-Binary-Patches/build_config.json

--- a/README.md
+++ b/README.md
@@ -11,19 +11,79 @@ See [SETUP.md](./SETUP.md).
 
 To apply patcher on patch files run this command:
 
-`python main.py [path to folder with patches] [path to clang++ executable] [path to linker executable (ld)] [path to g++ executable]`
+`python main.py [path to config file]`
+
+config structure:
+```json
+{
+    // path to target folder. Can be either relative or absolute.
+    // if relative path then it will be {config path}/{target_folder_path}
+    "target_folder_path": "FA-Binary-Patches",
+    // path to build folder. Defaults to "{target_folder_path}/build"
+    "build_folder_path": null,
+    // paths of input and output files
+    "input_exe_path": "ForgedAlliance_base.exe",
+    "output_exe_path": "C:\\ProgramData\\FAForever\\bin\\ForgedAlliance_exxt.exe",
+    // path to clang++ compiler. Defaults to "clang++"
+    "clang": "clang++.exe",
+    // path to g++ compiler. Defaults to "g++"
+    "gcc": "g++.exe",
+    // path to linker. Defaults to "ld"
+    "linker": "ld.exe",
+    // flags for compilers
+    "clang_flags": [
+        "-pipe",
+        "-m32",
+        "-O3",
+        "-nostdlib",
+        "-Werror",
+        "-masm=intel",
+        "-std=c++20",
+        "-march=core2"
+    ],
+    "gcc_flags": [
+        "-pipe",
+        "-m32",
+        "-Os",
+        "-fno-exceptions",
+        "-nostdlib",
+        "-nostartfiles",
+        "-fpermissive",
+        "-masm=intel",
+        "-std=c++20",
+        "-march=core2",
+        "-mfpmath=both"
+    ],
+    "asm_flags": [
+        "-pipe",
+        "-m32",
+        "-Os",
+        "-fno-exceptions",
+        "-nostdlib",
+        "-nostartfiles",
+        "-w",
+        "-fpermissive",
+        "-masm=intel",
+        "-std=c++20",
+        "-march=core2",
+        "-mfpmath=both"
+    ],
+}
+```
 
 ## Patches folder structure
 
 - **/build**: Here happens build for all source files. Patcher leaves address maps after build for debug purposes.
+- **/hooks**: All files with asm that is injected by specified addresses. 
 - **/include**: Header files.
 - **/section**: All files with patches that involve logic written with C/C++. 
   - `*.cpp` files are built with *g++*
   - `*.cxx` files are built with *clang++*
   - Can contain nested folders
   - Can contain header files
-- **/hooks**: All files with asm that is injected by specified addresses. 
-- ***define.h***: Generated file for hooks to use.
+  - Can contain `.hook` files
+- ***config.json***: Config file for patcher.
+- ***section.ld***: Main linker script.
 - ***SigPatches.txt***: File with signature patches. Replaces one binary sequence with another. Applied after build.
 - ***ForgedAlliance_base.exe***: Base executable of the game for patching.
 - ***ForgedAlliance_exxt.exe***: Result executable, run with [debugger](https://github.com/FAForever/FADeepProbe) for more information in case of crashes.
@@ -33,18 +93,18 @@ To apply patcher on patch files run this command:
 Versions of compilers and linkers used.
 
 clang++ compiler: 
-* version 18.1.8
+* clang version 21.1.0
 * Target: x86_64-pc-windows-msvc
 * Thread model: posix
 
 ld linker:
-* GNU ld (GNU Binutils) 2.40
+* GNU ld (GNU Binutils) 2.39
 
 g++ compiler:
-* g++ (Rev6, Built by MSYS2 project) 13.1.0
+* g++ (i686-posix-dwarf-rev0, Built by MinGW-Builds project) 13.2.0      
 
 python:
-* 3.12.4
+* 3.14.2
 
 # HumanUserCalls.py
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ config structure:
         "-std=c++20",
         "-march=core2",
         "-mfpmath=both"
-    ],
+    ]
 }
 ```
 

--- a/config_example.json
+++ b/config_example.json
@@ -1,0 +1,45 @@
+{
+    "target_folder_path": "FA-Binary-Patches",
+    "input_exe_path": "ForgedAlliance_base.exe",
+    "output_exe_path": "C:\\ProgramData\\FAForever\\bin\\ForgedAlliance_exxt.exe",
+    "clang": "clang++.exe",
+    "gcc": "g++.exe",
+    "linker": "ld.exe",
+    "clang_flags": [
+        "-pipe",
+        "-m32",
+        "-O3",
+        "-nostdlib",
+        "-Werror",
+        "-masm=intel",
+        "-std=c++20",
+        "-march=core2"
+    ],
+    "gcc_flags": [
+        "-pipe",
+        "-m32",
+        "-Os",
+        "-fno-exceptions",
+        "-nostdlib",
+        "-nostartfiles",
+        "-fpermissive",
+        "-masm=intel",
+        "-std=c++20",
+        "-march=core2",
+        "-mfpmath=both"
+    ],
+    "asm_flags": [
+        "-pipe",
+        "-m32",
+        "-Os",
+        "-fno-exceptions",
+        "-nostdlib",
+        "-nostartfiles",
+        "-w",
+        "-fpermissive",
+        "-masm=intel",
+        "-std=c++20",
+        "-march=core2",
+        "-mfpmath=both"
+    ]
+}

--- a/main.py
+++ b/main.py
@@ -4,6 +4,6 @@ import patcher
 
 if __name__ == "__main__":
     start = time.time()
-    patcher.patch(*sys.argv)
+    patcher.patch(*sys.argv[1:])
     end = time.time()
     print(f"Patched in {end-start:.2f}s")

--- a/patcher/Config.py
+++ b/patcher/Config.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+from dataclasses import dataclass, field
+from typing import Self
+
+
+@dataclass
+class Config:
+    path: Path
+    target_folder_path: Path
+    build_folder_path: Path
+    input_exe_path: Path = "ForgedAlliance_base.exe"
+    output_exe_path: Path = "ForgedAlliance_exxt.exe"
+
+    clang_path: Path = "clang++"
+    gcc_path: Path = "g++"
+    linker_path: Path = "ld"
+
+    clang_flags: tuple[str] = ()
+    gcc_flags: tuple[str] = ()
+    asm_flags: tuple[str] = ()
+
+    @classmethod
+    def load_from_json(cls, path: Path) -> Self:
+        path = Path(path).resolve()
+        with open(path, 'r') as f:
+            config = json.load(f)
+
+        return cls(
+            path=path,
+            target_folder_path=config.get("target_folder_path", path.parent),
+            build_folder_path=config.get("build_folder_path"),
+            input_exe_path=config.get("input_exe_path", Config.input_exe_path),
+            output_exe_path=config.get(
+                "output_exe_path", Config.output_exe_path),
+            clang_path=config.get("clang", Config.clang_path),
+            gcc_path=config.get("gcc", Config.gcc_path),
+            linker_path=config.get("linker", Config.linker_path),
+            clang_flags=config.get("clang_flags", Config.clang_flags),
+            gcc_flags=config.get("gcc_flags", Config.gcc_flags),
+            asm_flags=config.get("asm_flags", Config.asm_flags),
+        )
+
+    def __post_init__(self):
+        self.target_folder_path = Path(self.target_folder_path)
+        self.input_exe_path = Path(self.input_exe_path)
+        self.output_exe_path = Path(self.output_exe_path)
+
+        if not self.target_folder_path.is_absolute():
+            self.target_folder_path = self.path.parent / self.target_folder_path
+
+        self.build_folder_path = Path(self.build_folder_path)\
+            if self.build_folder_path \
+            else self.target_folder_path / "build"
+
+        self.clang_path = Path(self.clang_path)
+        self.gcc_path = Path(self.gcc_path)
+        self.linker_path = Path(self.linker_path)
+
+        if not self.build_folder_path.is_absolute():
+            raise ValueError(
+                "build_folder_path must be an absolute path to folder")
+
+    @property
+    def input_path(self) -> Path:
+        if self.input_exe_path.is_absolute():
+            return self.input_exe_path
+        return self.target_folder_path / self.input_exe_path
+
+    @property
+    def output_path(self) -> Path:
+        if self.output_exe_path.is_absolute():
+            return self.output_exe_path
+        return self.build_folder_path / self.output_exe_path

--- a/patcher/Hook.py
+++ b/patcher/Hook.py
@@ -3,29 +3,40 @@ from pathlib import Path
 
 ADDRESS_RE = re.compile(r"^(0[xX][0-9A-Fa-f]{6,8})\:$")
 FUNCTION_NAME_RE = re.compile(r"@([a-zA-Z\_][a-zA-Z0-9\_]+)")
+ESCAPE_TRANSLATION = str.maketrans({"\"":  r"\"", "\\": r"\\", })
 
 
 class Section:
 
-    def __init__(self, address: str, lines: list[str]) -> None:
+    def __init__(self, address: str, lines: list[str], addresses: dict[str, str]) -> None:
         self._address: str = address
         self._lines: list[str] = lines
+        self._addresses: dict[str, str] = addresses
 
     def lines_to_cpp(self):
-        s = ""
+        s = []
         for line in self._lines:
-            line = line.translate(str.maketrans({"\"":  r"\"", "\\": r"\\", }))
+            # line = line.translate(ESCAPE_TRANSLATION)
+
+            def replace_address(match: re.Match[str]) -> str:
+                func_name = match.group(1)
+                if func_name in self._addresses:
+                    return f'{match.group(1)} /* {self._addresses[func_name]} */'
+                return match.group(0)
 
             if FUNCTION_NAME_RE.findall(line):
-                line = FUNCTION_NAME_RE.subn(r'"QU(\1)"', line)[0]
+                line = FUNCTION_NAME_RE.subn(replace_address, line)[0]
 
-            s += f'"{line};"\n'
-        return s
+            s.append(f'{line};')
+        return "\n".join(s)
+
+    def header(self, index: int) -> str:
+        if self._address is None:
+            return ""
+        return f'.section h{index:X}; .set h{index:X},{self._address};'
 
     def to_cpp(self, index: int) -> str:
-        if self._address is None:
-            return self.lines_to_cpp()
-        return f'SECTION({index:X}, {self._address})\n{self.lines_to_cpp()}'
+        return f'{self.header(index)}\n{self.lines_to_cpp()}'
 
 
 class Hook:
@@ -33,15 +44,16 @@ class Hook:
         self._sections: list[Section] = sections
 
     def to_cpp(self):
-        s = '#include "../asm.h"\n#include "../define.h"\n'
+        s = ''
         if len(self._sections) > 0:
             sections_lines = (section.to_cpp(i).split("\n")
                               for i, section in enumerate(self._sections))
-            s += f"asm(\n{''.join((f"    {line}\n" for lines in sections_lines for line in lines))});"
+            s += f"asm(R\"(\n{''.join((f"    {line}\n" if not line.startswith(".section") else f'\n{line}\n'
+                                       for lines in sections_lines for line in lines))})\");"
         return s
 
 
-def load_hook(file_path: Path) -> Hook:
+def load_hook(file_path: Path, addresses: dict[str, str]) -> Hook:
     sections: list[Section] = []
     lines = []
     address = None
@@ -56,11 +68,11 @@ def load_hook(file_path: Path) -> Hook:
 
             if match := ADDRESS_RE.match(line):
                 if len(lines) > 0:
-                    sections.append(Section(address, lines))
+                    sections.append(Section(address, lines, addresses))
                 lines = []
                 address = match.group(1)
                 continue
             lines.append(line)
         if len(lines) > 0:
-            sections.append(Section(address, lines))
+            sections.append(Section(address, lines, addresses))
         return Hook(sections)

--- a/patcher/Hook.py
+++ b/patcher/Hook.py
@@ -4,6 +4,12 @@ from pathlib import Path
 ADDRESS_RE = re.compile(r"^(0[xX][0-9A-Fa-f]{6,8})\:$")
 FUNCTION_NAME_RE = re.compile(r"@([a-zA-Z\_][a-zA-Z0-9\_]+)")
 ESCAPE_TRANSLATION = str.maketrans({"\"":  r"\"", "\\": r"\\", })
+NOP_MULT_RE = re.compile(r"nop\s+([1-9][0-9]*)", re.IGNORECASE)
+
+
+def replace_mulinop(match: re.Match[str]) -> str:
+    count = int(match.group(1))
+    return ";".join(["nop"] * count) + f" /* {count} */"
 
 
 class Section:
@@ -26,6 +32,9 @@ class Section:
 
             if FUNCTION_NAME_RE.findall(line):
                 line = FUNCTION_NAME_RE.subn(replace_address, line)[0]
+
+            if NOP_MULT_RE.findall(line):
+                line = NOP_MULT_RE.subn(replace_mulinop, line)[0]
 
             s.append(f'{line};')
         return "\n".join(s)

--- a/patcher/PEData.py
+++ b/patcher/PEData.py
@@ -76,4 +76,4 @@ class PEData(BasicBinaryParser):
         for sect in self.sects:
             if sect.name == name:
                 return sect
-        return None
+        raise Exception(f"Couldn't find section {name}")

--- a/patcher/Patcher.py
+++ b/patcher/Patcher.py
@@ -218,6 +218,7 @@ def apply_sig_patches(file_path: Path, data: bytearray):
 
 
 def run_process(args, cwd: Optional[str] = None) -> bool:
+    print(" ".join((str(arg) for arg in args)))
     result = subprocess.run(args, cwd=cwd)
     return result.returncode != 0
 

--- a/section_example.ld
+++ b/section_example.ld
@@ -1,0 +1,41 @@
+OUTPUT_FORMAT(pei-i386)
+OUTPUT(section.pe)
+
+"_atexit"                   = 0xA8211E;
+"__Znwj"                    = 0xA825B9;
+"__ZdlPvj"                  = 0x958C40;
+"__imp__GetModuleHandleA@4" = 0xC0F378;
+"__imp__GetProcAddress@8"   = 0xC0F48C;
+"___CxxFrameHandler3"       = 0xA8958C;
+"___std_terminate"          = 0xA994FB;
+"??_7type_info@@6B@"        = 0xD72A88;
+"__CxxThrowException@8"     = 0xA89950;
+"_memset"                   = 0xA89110;
+"__invoke_watson"           = 0xA848E8;
+"_strcpy"                   = 0xA944E0;
+"_memcpy"                   = 0xA84A60;
+
+SECTIONS {
+    . = __image_base__ + 0x1000;
+    .text : {
+        *(.text*)
+        *(.data*)
+        *(.bss*)
+        *(.rdata)
+    }
+    .ctors : {
+        _FIRST_CTOR = .;
+        *(.ctors)
+        *(.CRT*)
+        _END_CTOR = .;
+    }
+    .clang : {
+        clangfile.o
+    }
+    /DISCARD/ : {
+        *(.rdata$zzz)
+        *(.eh_frame*)
+        *(.reloc)
+        *(.idata*)
+    }
+}


### PR DESCRIPTION
This is a major patcher change that refines patching process and includes new features:
* patcher uses `.json` config for patching game executable with adjustable paths and flags
* no more `defines.h` file
* `section.ld` file was changed to contain all info needed for linker, patcher just appends addresses
* `.hooks` are refined: these can be placed in sections folder so hook is near its respective .cxx/.cpp file
    - names used in hooks are placed directly into the generated file, that means all places where address was used must now use `offset`, like `push @OBSTRUCTSBUILDING` -> `push offset @OBSTRUCTSBUILDING`
* `*.cpp` hooks are deprecated and prohibited to be used in further patches, use `.hook`
* `.hook` support `nop n` macro to put multiple nops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced CLI with a single config-file-driven workflow and added a JSON config example.
  * Added an example linker script for PE i386 builds.

* **Documentation**
  * Reorganized patching docs to describe hook-based, per-file patch placement and updated run/setup guide and file/folder taxonomy.

* **Versions**
  * Updated supported toolchain and runtime versions.

* **Tests/CI**
  * CI workflow updated (Python 3.14) and adjusted patching invocation/location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->